### PR TITLE
Remove duplicate key from language array

### DIFF
--- a/resources/lang/en/surveillance.php
+++ b/resources/lang/en/surveillance.php
@@ -3,7 +3,6 @@
 return [
     "messages" => [
         'enabled' => "\nSurveillance has been enabled.\n",
-        'already-enabled' => "\nSurveillance is already enabled.\n",
         'disabled' => "\nSurveillance has been disabled.\n",
         'already-enabled' => "\nSurveillance is already disabled.\n",
         'blocked' => "\nAccess has been blocked.\n",
@@ -11,9 +10,9 @@ return [
         'unblocked' => "\nAccess has been unblocked.\n",
         'already-unblocked' => "\nAccess is already unblocked.\n",
         'record-removed' => "\nSurveillance record(s) removed.\n",
-        "record-not-found" => "\nNo existing record(s) found for type: [:type] and value: [:value].\n",
-        "confirm" => "Are you sure?",
-        "console-validation-failed" => "\nValidation failed.\n",
-        "console-allowed-types" => "Invalid 'type'. Only following types are allowed: [ :types ]"
+        'record-not-found' => "\nNo existing record(s) found for type: [:type] and value: [:value].\n",
+        'confirm' => "Are you sure?",
+        'console-validation-failed' => "\nValidation failed.\n",
+        'console-allowed-types' => "Invalid 'type'. Only following types are allowed: [ :types ]"
     ]
 ];


### PR DESCRIPTION
A PHP array cannot have two elements with the same key: `already-enabled`

Please consider running static analysis.